### PR TITLE
razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -380,6 +380,13 @@ namespace stoat {
                 return staticEval;
             }
 
+            if (depth <= 3 && std::abs(alpha) < 2000 && staticEval + 300 * depth <= alpha) {
+                const auto score = qsearch(thread, pos, ply, alpha, alpha + 1);
+                if (score <= alpha) {
+                    return score;
+                }
+            }
+
             if (depth >= 4 && staticEval >= beta && !parent->move.isNull()) {
                 static constexpr i32 kR = 3;
 


### PR DESCRIPTION
```
Elo   | 16.95 +- 8.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4062 W: 2015 L: 1817 D: 230
Penta | [288, 80, 1191, 90, 382]
```
https://chess.swehosting.se/test/9739/