### PR TITLE
hindsight reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -577,6 +577,10 @@ namespace stoat {
         }();
 
         if (!ttPv && !pos.isInCheck() && !curr.excluded && complexity <= 20) {
+            if (parent && depth >= 2 && parent->reduction >= 1 && curr.staticEval + parent->staticEval >= 200) {
+                depth--;
+            }
+
             if (depth <= 10 && curr.staticEval - 80 * (depth - improving) >= beta) {
                 return curr.staticEval;
             }
@@ -725,7 +729,9 @@ namespace stoat {
                 r -= history / 8192;
 
                 const auto reduced = std::min(std::max(newDepth - r, 1), newDepth - 1);
+                curr.reduction = newDepth - reduced;
                 score = -search(thread, newPos, curr.pv, reduced, ply + 1, -alpha - 1, -alpha, true);
+                curr.reduction = 0;
 
                 if (score > alpha && reduced < newDepth) {
                     score = -search(thread, newPos, curr.pv, newDepth, ply + 1, -alpha - 1, -alpha, !expectedCutnode);

--- a/src/thread.h
+++ b/src/thread.h
@@ -87,6 +87,7 @@ namespace stoat {
         Move move{};
         Score staticEval{};
         Move excluded{};
+        i32 reduction{};
     };
 
     struct alignas(kCacheLineSize) ThreadData {


### PR DESCRIPTION
Elo   | 5.40 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 22734 W: 10934 L: 10581 D: 1219
Penta | [2367, 574, 5309, 573, 2544]
https://chess.swehosting.se/test/11348/

bench 3936438