### PR TITLE
fix incorrect dropPiece mapping in `convertToOldFormat`

### DIFF
--- a/src/datagen/format/stoatpack.cpp
+++ b/src/datagen/format/stoatpack.cpp
@@ -27,11 +27,11 @@ namespace stoat::datagen::format {
                 return move;
             }
 
-            // new: P, L, N, S, B, R, G, K, +P, +L, +N, +S, +B, +R
-            // old: P, +P, L, N, +L, +N, S, +S, G, B, R, +B, +R, K
-            constexpr std::array kPieceTypeMap{0, 2, 3, 6, 9, 10, 8, 13, 1, 4, 5, 7, 11, 12};
+            // new: P, L, N, S, B, R, G
+            // old: P, L, N, S, G, B, R
+            constexpr std::array kDropPieceMap{0, 1, 2, 3, 5, 6, 4};
 
-            return Move::makeDrop(PieceType::fromRaw(kPieceTypeMap[move.dropPiece().idx()]), move.to());
+            return Move::makeDrop(PieceType::fromRaw(kDropPieceMap[move.dropPiece().idx()]), move.to());
         }
     } // namespace
 


### PR DESCRIPTION
I forgot that the old format packed drop pieces into 0..=6, so I updated the mapping to match

Bench: 3633468